### PR TITLE
Preserve callee saved registers.

### DIFF
--- a/src/main/java/com/bai/solver/PcodeVisitor.java
+++ b/src/main/java/com/bai/solver/PcodeVisitor.java
@@ -738,6 +738,12 @@ public class PcodeVisitor {
                 }
             } else {
                 for (JImmutableMap.Entry<ALoc, KSet> entry : exit) {
+                    if (GlobalState.config.getPreserveCalleeSavedReg()) {
+                        // do not overwrite callee saved register
+                        if (GlobalState.arch.isCalleeSavedRegister(entry.getKey())) {
+                            continue;
+                        }
+                    }
                     inOutEnv.set(entry.getKey(), entry.getValue(), true);
                 }
             }
@@ -877,6 +883,12 @@ public class PcodeVisitor {
 
         if (isFinished) {
             for (JImmutableTreeMap.Entry<ALoc, KSet> entry : resEnv.getEnvMap()) {
+                if (GlobalState.config.getPreserveCalleeSavedReg()) {
+                    // do not overwrite callee saved register
+                    if (GlobalState.arch.isCalleeSavedRegister(entry.getKey())) {
+                        continue;
+                    }
+                }
                 inOutEnv.set(entry.getKey(), entry.getValue(), true);
             }
         }

--- a/src/main/java/com/bai/util/Config.java
+++ b/src/main/java/com/bai/util/Config.java
@@ -56,6 +56,7 @@ public class Config {
             System.out.println("        [-disableZ3]");
             System.out.println("        [-all]");
             System.out.println("        [-debug]");
+            System.out.println("        [-PreserveCalleeSavedReg]");
             System.out.println("        [-check \"<cweNo1>[;<cweNo2>...]\"]");
         }
 
@@ -93,6 +94,8 @@ public class Config {
                         CheckerManager.loadAllCheckers(config);
                     } else if (arg.equalsIgnoreCase("-debug")) {
                         config.setDebug(true);
+                    } else if (arg.equalsIgnoreCase("-preserveCalleeSavedReg")) {
+                        config.setPreserveCalleeSavedReg(true);
                     } else if (checkArgument("-check", args, argi)) {
                         String[] checkers = getSubArguments(args, argi);
                         Arrays.stream(checkers)
@@ -142,6 +145,8 @@ public class Config {
 
     private boolean isGUI;
 
+    private boolean preserveCalleeSavedReg;
+
     // for tactic tuning, see:
     // http://www.cs.tau.ac.il/~msagiv/courses/asv/z3py/strategies-examples.htm
     private List<String> z3Tactics = new ArrayList<>();
@@ -157,6 +162,7 @@ public class Config {
         this.entryAddress = null;
         this.isEnableZ3 = true;
         this.externalMapPath = null;
+        this.preserveCalleeSavedReg = false;
     }
 
     /**
@@ -348,6 +354,22 @@ public class Config {
      */
     public void setGUI(boolean isGUI) {
         this.isGUI = isGUI;
+    }
+
+    /**
+     * Preserve the callee saved registers.
+     * @param preserveCalleeSavedReg preserve or not.
+     */
+    public void setPreserveCalleeSavedReg(boolean preserveCalleeSavedReg) {
+        this.preserveCalleeSavedReg = preserveCalleeSavedReg;
+    }
+
+    /**
+     *  Get if the callee saved registers are preserved.
+     * @return true if preserved, false otherwise.
+     */
+    public boolean getPreserveCalleeSavedReg() {
+        return preserveCalleeSavedReg;
     }
 
     @Override


### PR DESCRIPTION
抽象解释分析的过程中，如果某个函数有一些很深的函数调用，结尾的时候callee saved registers有时不能正常恢复（好像是因为栈上存的栈指针会乱掉，而栈结尾恢复callee saved registers的时候用的是这个栈上存的栈指针）。如果在抽象解释，函数调用返回的时候，直接保留callee saved registers能够有效地提升分析精度。

我在ARM系列架构上发现的这个问题，因此目前支持了保留ARM和AArch64的调用约定的callee saved registers。而且ARM系列的调用约定AAPCS比较统一。X86暂未在这次PR实现支持，而且X86的调用约定好像没那么统一。