### PR TITLE
Add MachO support

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: er28-0652/setup-ghidra@0.0.6
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          version: '10.4'
+          version: '11.1.2'
       - name: Download Z3
         uses: pavpanchekha/setup-z3@0.2.0
         if: steps.cache.outputs.cache-hit != 'true'
@@ -39,7 +39,7 @@ jobs:
         if: steps.cache.outputs.cache-hit == 'true'
         run: |
           echo "CPATH=/opt/hostedtoolcache/z3/4.8.15/x64/z3-4.8.15-x64-glibc-2.31/include" >> $GITHUB_ENV
-          echo "GHIDRA_INSTALL_DIR=/opt/hostedtoolcache/ghidra/10.4/x64" >> $GITHUB_ENV
+          echo "GHIDRA_INSTALL_DIR=/opt/hostedtoolcache/ghidra/11.1.2/x64" >> $GITHUB_ENV
       - name: Setup Z3
         run: |
           cp $CPATH/../bin/com.microsoft.z3.jar $GITHUB_WORKSPACE/lib/com.microsoft.z3.jar

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,7 +27,7 @@ jobs:
         uses: er28-0652/setup-ghidra@0.0.6
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          version: '10.4'
+          version: '11.1.2'
       - name: Download Z3
         uses: pavpanchekha/setup-z3@0.2.0
         if: steps.cache.outputs.cache-hit != 'true'
@@ -39,7 +39,7 @@ jobs:
         if: steps.cache.outputs.cache-hit == 'true'
         run: |
           echo "CPATH=/opt/hostedtoolcache/z3/4.8.15/x64/z3-4.8.15-x64-glibc-2.31/include" >> $GITHUB_ENV
-          echo "GHIDRA_INSTALL_DIR=/opt/hostedtoolcache/ghidra/10.4/x64" >> $GITHUB_ENV
+          echo "GHIDRA_INSTALL_DIR=/opt/hostedtoolcache/ghidra/11.1.2/x64" >> $GITHUB_ENV
       - name: Setup Z3
         run: |
           cp $CPATH/../bin/com.microsoft.z3.jar $GITHUB_WORKSPACE/lib/com.microsoft.z3.jar

--- a/src/main/java/com/bai/util/Utils.java
+++ b/src/main/java/com/bai/util/Utils.java
@@ -335,6 +335,15 @@ public class Utils {
             Logging.error("Empty symbol table");
             return new ArrayList<>();
         }
+
+        // OS X ABI for Mach-O format mangles C symbols by prepending an underscore (_) to symbols
+        if (GlobalState.currentProgram.getExecutableFormat().equals(MachoLoader.MACH_O_NAME)) {
+            List<String> machOMangledNames = symbolNames.stream()
+                    .map(name -> "_" + name)
+                    .toList();
+            symbolNames.addAll(machOMangledNames);
+        }
+
         return Stream.generate(() -> null)
                 .takeWhile(x -> symbolIterator.hasNext())
                 .map(n -> symbolIterator.next())


### PR DESCRIPTION
This PR introduces the following changes:
- Entrypoint detection for Mach-O / FAT binaries
- Different handling of reference symbols for Mach-O binaries, that are used by checkers. OSX Mach-O ABI enforces mangling (leading underscore) even for C symbols (e.g malloc -> _malloc). 

The changes have been implemented/tested on MacOS 14.6 (Sonoma) / ARM - M2 and Ghidra 11.1.2. 

If its needed I can also add arm64 / Mach-O binaries to https://github.com/KeenSecurityLab/BinAbsInspector-binaries and add the respective integration tests.
